### PR TITLE
Fix reproducibility of initial conditions with the same random seed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.13"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/src/harmonwig/harmonwig.py
+++ b/src/harmonwig/harmonwig.py
@@ -72,7 +72,7 @@ class HarmonicWigner:
             sigma = math.sqrt(0.5)
             freq_factor = math.sqrt(mode["freq"])
 
-            Q = random.gauss(mu=0.0, sigma=sigma)
+            Q = self.rnd.gauss(mu=0.0, sigma=sigma)
             Q /= freq_factor
             # TODO: Sample momenta as well, attach them to ASE object as velocities
             # P = random.gauss(mu=0.0, sigma=sigma)

--- a/tests/test_harmonicwigner_class.py
+++ b/tests/test_harmonicwigner_class.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+from ase import Atoms
+
+from harmonwig import HarmonicWigner
+
+
+@pytest.fixture
+def mock_h2o_molecule():
+    """Create a simple water molecule for testing"""
+    positions = [
+        [0.0, 0.0, 0.0],  # O
+        [0.0, 0.757, 0.586],  # H
+        [0.0, -0.757, 0.586],
+    ]  # H
+    return Atoms("OH2", positions=positions)
+
+
+@pytest.fixture
+def mock_h2o_frequencies():
+    """Mock H2O vibrational frequencies in cm^-1"""
+    # Real vibrational frequencies for H2O
+    return [
+        3657.0,  # symmetric stretch
+        3756.0,  # antisymmetric stretch
+        1595.0,
+    ]  # bending
+
+
+@pytest.fixture
+def mock_h2o_vibrations():
+    """Mock vibrational normal modes"""
+    # Simplified normal modes for testing
+    vibrations = []
+
+    # Symmetric stretch - both H atoms move in same direction
+    vibrations.append(
+        [
+            [0.0, 0.0, 0.0],  # O stays relatively still
+            [0.0, 0.0, 1.0],  # H1 moves up
+            [0.0, 0.0, 1.0],  # H2 moves up
+        ]
+    )
+
+    # Antisymmetric stretch - H atoms move in opposite directions
+    vibrations.append(
+        [
+            [0.0, 0.0, 0.0],  # O stays relatively still
+            [0.0, 0.0, 1.0],  # H1 moves up
+            [0.0, 0.0, -1.0],  # H2 moves down
+        ]
+    )
+
+    # Bending - H atoms move in opposite directions perpendicular to bonds
+    vibrations.append(
+        [
+            [0.0, 0.0, 0.0],  # O stays relatively still
+            [0.0, 1.0, 0.0],  # H1 moves right
+            [0.0, -1.0, 0.0],  # H2 moves left
+        ]
+    )
+
+    return vibrations
+
+
+def test_sample_reproducibility(
+    mock_h2o_molecule, mock_h2o_frequencies, mock_h2o_vibrations
+):
+    """Test that using the same seed produces identical samples"""
+    hw1 = HarmonicWigner(
+        mock_h2o_molecule, mock_h2o_frequencies, mock_h2o_vibrations, seed=42
+    )
+
+    hw2 = HarmonicWigner(
+        mock_h2o_molecule, mock_h2o_frequencies, mock_h2o_vibrations, seed=42
+    )
+
+    sample1 = hw1.get_ase_sample()
+    sample2 = hw2.get_ase_sample()
+
+    # Positions should be identical for same seed
+    np.testing.assert_array_equal(sample1.get_positions(), sample2.get_positions())

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,5 +1,6 @@
 import harmonwig
 
 
-def test_dummy():
-    print(harmonwig.__version__)
+def test_version():
+    """Test the presense of `__version__` attribute"""
+    print(f"harmonwig version: {harmonwig.__version__}")


### PR DESCRIPTION
Although we were initializing the PRNG with the random seed correctly, we then forgot to use it. :-(
This is embarassing, but fortunately does not affect the code in Atmospec which does it correctly.